### PR TITLE
Add ability to force crop shape and aspect ratio

### DIFF
--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
@@ -32,7 +32,7 @@ interface CropState {
     var shape: CropShape
     val accepted: Boolean
     fun done(accept: Boolean)
-    fun reset()
+    fun reset(forceShape: CropShape?)
 }
 
 fun cropState(
@@ -74,9 +74,9 @@ fun cropState(
         _region = new.asMatrix(src.size).map(unTransform.map(region))
     }
 
-    override fun reset() {
+    override fun reset(forceShape: CropShape?) {
         transform = defaultTransform
-        shape = defaultShape
+        shape = forceShape ?: defaultShape
         _region = defaultRegion
         aspectLock = defaultAspectLock
     }

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
@@ -53,6 +53,9 @@ interface CropperStyle {
     /** All available aspect ratios */
     val aspects: List<AspectRatio>
 
+    /** Force an aspect ratio, other aspects will be ignored */
+    val forceAspectRatio: AspectRatio?
+
     /** Whether the view needs to be zoomed in automatically
      * to fit the crop rect after any change */
     val autoZoom: Boolean
@@ -92,6 +95,7 @@ fun cropperStyle(
     shapes: List<CropShape>? = DefaultCropShapes,
     forceShape: CropShape? = null,
     aspects: List<AspectRatio> = DefaultAspectRatios,
+    forceAspectRatio: AspectRatio? = null,
     autoZoom: Boolean = true,
 ): CropperStyle = object : CropperStyle {
     override val touchRad: Dp get() = touchRad
@@ -100,6 +104,7 @@ fun cropperStyle(
     override val shapes: List<CropShape>? get() = shapes?.takeIf { it.isNotEmpty() }
     override val forceShape: CropShape? get() = forceShape
     override val aspects get() = aspects
+    override val forceAspectRatio: AspectRatio? get() = forceAspectRatio
     override val autoZoom: Boolean get() = autoZoom
 
     override fun DrawScope.drawCropRect(region: Rect) {

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
@@ -47,6 +47,9 @@ interface CropperStyle {
     /** All available crop shapes */
     val shapes: List<CropShape>?
 
+    /** Force a crop shape, list of shapes will be ignored */
+    val forceShape: CropShape?
+
     /** All available aspect ratios */
     val aspects: List<AspectRatio>
 
@@ -87,6 +90,7 @@ fun cropperStyle(
     secondaryHandles: Boolean = true,
     overlay: Color = Color.Black.copy(alpha = .5f),
     shapes: List<CropShape>? = DefaultCropShapes,
+    forceShape: CropShape? = null,
     aspects: List<AspectRatio> = DefaultAspectRatios,
     autoZoom: Boolean = true,
 ): CropperStyle = object : CropperStyle {
@@ -94,6 +98,7 @@ fun cropperStyle(
     override val backgroundColor: Color get() = backgroundColor
     override val overlayColor: Color get() = overlay
     override val shapes: List<CropShape>? get() = shapes?.takeIf { it.isNotEmpty() }
+    override val forceShape: CropShape? get() = forceShape
     override val aspects get() = aspects
     override val autoZoom: Boolean get() = autoZoom
 

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
@@ -80,20 +80,24 @@ fun CropperControls(
             IconButton(onClick = { state.flipVertical() }) {
                 Icon(painterResource(Res.drawable.flip_ver), null)
             }
-            Box {
-                var menu by remember { mutableStateOf(false) }
-                IconButton(onClick = { menu = !menu }) {
-                    Icon(painterResource(Res.drawable.resize), null)
-                }
-                if (menu) AspectSelectionMenu(
-                    onDismiss = { menu = false },
-                    region = state.region,
-                    onRegion = { state.region = it },
-                    lock = state.aspectLock,
-                    onLock = { state.aspectLock = it }
-                )
-            }
 
+            LocalCropperStyle.current.forceAspectRatio?.let {
+                state.aspectLock = true
+            } ?: run {
+                Box {
+                    var menu by remember { mutableStateOf(false) }
+                    IconButton(onClick = { menu = !menu }) {
+                        Icon(painterResource(Res.drawable.resize), null)
+                    }
+                    if (menu) AspectSelectionMenu(
+                        onDismiss = { menu = false },
+                        region = state.region,
+                        onRegion = { state.region = it },
+                        lock = state.aspectLock,
+                        onLock = { state.aspectLock = it }
+                    )
+                }
+            }
             LocalCropperStyle.current.forceShape?.let {
                 state.shape = it
             } ?: run {

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
@@ -93,18 +93,23 @@ fun CropperControls(
                     onLock = { state.aspectLock = it }
                 )
             }
-            LocalCropperStyle.current.shapes?.let { shapes ->
-                Box {
-                    var menu by remember { mutableStateOf(false) }
-                    IconButton(onClick = { menu = !menu }) {
-                        Icon(Icons.Default.Star, null)
+
+            LocalCropperStyle.current.forceShape?.let {
+                state.shape = it
+            } ?: run {
+                LocalCropperStyle.current.shapes?.let { shapes ->
+                    Box {
+                        var menu by remember { mutableStateOf(false) }
+                        IconButton(onClick = { menu = !menu }) {
+                            Icon(Icons.Default.Star, null)
+                        }
+                        if (menu) ShapeSelectionMenu(
+                            onDismiss = { menu = false },
+                            selected = state.shape,
+                            onSelect = { state.shape = it },
+                            shapes = shapes
+                        )
                     }
-                    if (menu) ShapeSelectionMenu(
-                        onDismiss = { menu = false },
-                        selected = state.shape,
-                        onSelect = { state.shape = it },
-                        shapes = shapes
-                    )
                 }
             }
         }

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -27,6 +27,7 @@ import com.attafitamim.krop.core.crop.asMatrix
 import com.attafitamim.krop.core.crop.cropperTouch
 import com.attafitamim.krop.core.images.rememberLoadedImage
 import com.attafitamim.krop.core.utils.ViewMat
+import com.attafitamim.krop.core.utils.setAspect
 import com.attafitamim.krop.core.utils.times
 import com.attafitamim.krop.core.utils.viewMat
 import kotlinx.coroutines.delay
@@ -45,6 +46,11 @@ fun CropperPreview(
     val viewPadding = LocalDensity.current.run { style.touchRad.toPx() }
     val totalMat = remember(viewMat.matrix, imgMat) { imgMat * viewMat.matrix }
     val image = rememberLoadedImage(state.src, view, totalMat)
+
+    style.forceAspectRatio?.let {
+        state.region = state.region.setAspect(it)
+    }
+
     val cropRect = remember(state.region, viewMat.matrix) {
         viewMat.matrix.map(state.region)
     }

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
@@ -89,6 +89,8 @@ fun BoxScope.DefaultControls(state: CropState) {
 
 @Composable
 fun DefaultTopBar(state: CropState) {
+    val style = LocalCropperStyle.current
+
     TopAppBar(title = {},
         navigationIcon = {
             IconButton(onClick = { state.done(accept = false) }) {
@@ -96,7 +98,7 @@ fun DefaultTopBar(state: CropState) {
             }
         },
         actions = {
-            IconButton(onClick = { state.reset() }) {
+            IconButton(onClick = { state.reset(style.forceShape) }) {
                 Icon(painterResource(Res.drawable.restore), null)
             }
             IconButton(onClick = { state.done(accept = true) }, enabled = !state.accepted) {


### PR DESCRIPTION
For my use case, I always need circular cropped images, so I added these 2 missing options to the library:

Add the ability to force:
- Crop shape
- Aspect ratio

Both can be set using the `CropperStyle`