### PR TITLE
Zooming improvements

### DIFF
--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
@@ -28,6 +28,7 @@ interface CropState {
     val src: ImageSrc
     var transform: ImgTransform
     var region: Rect
+    val defaultRegion: Rect
     var aspectLock: Boolean
     var shape: CropShape
     val accepted: Boolean
@@ -51,7 +52,7 @@ fun cropState(
             _transform = value
         }
 
-    val defaultRegion = src.size.toSize().toRect()
+    override val defaultRegion = src.size.toSize().toRect()
 
     private var _region by mutableStateOf(defaultRegion)
     override var region

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Touch.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Touch.kt
@@ -1,5 +1,6 @@
 package com.attafitamim.krop.core.crop
 
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -10,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.toOffset
 import com.attafitamim.krop.core.utils.ViewMat
+import com.attafitamim.krop.core.utils.ZoomLimits
 import com.attafitamim.krop.core.utils.abs
 import com.attafitamim.krop.core.utils.dragState
 import com.attafitamim.krop.core.utils.onGestures
@@ -33,6 +35,7 @@ fun Modifier.cropperTouch(
     viewMat: ViewMat,
     pending: DragHandle?,
     onPending: (DragHandle?) -> Unit,
+    zoomLimits: ZoomLimits,
 ): Modifier = composed {
     val touchRadPx2 = LocalDensity.current.run {
         remember(touchRad, viewMat.scale) { touchRad.toPx() / viewMat.scale }.let { it * it }
@@ -60,7 +63,7 @@ fun Modifier.cropperTouch(
                         val delta = (localPos - pending.initialPos).round().toOffset()
                         val newRegion = if (pending.handle != MoveHandle) {
                             pending.initialRegion
-                                .resize(pending.handle, delta)
+                                .resize(pending.handle, delta, zoomLimits.minCropSize)
                         } else {
                             pending.initialRegion.translate(delta)
                         }

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Touch.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Touch.kt
@@ -35,6 +35,7 @@ fun Modifier.cropperTouch(
     viewMat: ViewMat,
     pending: DragHandle?,
     onPending: (DragHandle?) -> Unit,
+    zooming: MutableState<Boolean>,
     zoomLimits: ZoomLimits,
 ): Modifier = composed {
     val touchRadPx2 = LocalDensity.current.run {
@@ -44,8 +45,12 @@ fun Modifier.cropperTouch(
     onGestures(
         rememberGestureState(
             zoom = zoomState(
-                begin = { c -> viewMat.zoomStart(c) },
-                next = { s, c -> viewMat.zoom(c, s) },
+                begin = { c ->
+                    viewMat.zoomStart(c)
+                    zooming.value = true
+                },
+                next = { s, c -> viewMat.zoom(c, s, zoomLimits) },
+                done = { zooming.value = false }
             ),
             drag = dragState(
                 begin = { pos ->

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import com.attafitamim.krop.core.crop.AspectRatio
+import com.attafitamim.krop.core.crop.ImgTransform
 import kotlin.math.absoluteValue
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -167,3 +168,11 @@ fun Rect.align(alignment: Int): Rect = Rect(
     left.alignDown(alignment), top.alignDown(alignment),
     right.alignUp(alignment), bottom.alignUp(alignment)
 )
+
+fun Rect.applyTransformation(transform: ImgTransform): Rect {
+    return if ((transform.angleDeg + 360) % 360 in listOf(90, 270)) {
+        Rect(this.top, this.left, this.bottom, this.right)
+    } else {
+        this
+    }
+}

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
@@ -88,15 +88,17 @@ fun IntRect.constrainOffset(bounds: IntRect): IntRect {
 fun Rect.resize(
     handle: Offset,
     delta: Offset,
+    maxZoomSize: Int,
 ): Rect {
     var (l, t, r, b) = this
     val (dx, dy) = delta
-    if (handle.y == 1f) b += dy
-    else if (handle.y == 0f) t += dy
-    if (handle.x == 1f) r += dx
-    else if (handle.x == 0f) l += dx
-    if (l > r) l = r.also { r = l }
-    if (t > b) t = b.also { b = t }
+
+    if (handle.y == 1f) b = (b + dy).coerceAtLeast(t + maxZoomSize)
+    else if (handle.y == 0f) t = (t + dy).coerceAtMost(b - maxZoomSize)
+
+    if (handle.x == 1f) r = (r + dx).coerceAtLeast(l + maxZoomSize)
+    else if (handle.x == 0f) l = (l + dx).coerceAtMost(r - maxZoomSize)
+
     return Rect(l, t, r, b)
 }
 

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ViewMat.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ViewMat.kt
@@ -17,6 +17,7 @@ interface ViewMat {
     fun zoomStart(center: Offset)
     fun zoom(center: Offset, scale: Float)
     suspend fun fit(inner: Rect, outer: Rect)
+    fun setOriginalScale(defaultRegion: Rect, outer: Rect)
     fun snapFit(inner: Rect, outer: Rect)
     val matrix: Matrix
     val invMatrix: Matrix
@@ -24,6 +25,7 @@ interface ViewMat {
 }
 
 fun viewMat() = object : ViewMat {
+    private var originalScale: Float = 1f
     var c0 = Offset.Zero
     var mat by mutableStateOf(Matrix(), neverEqualPolicy())
     val inv by derivedStateOf {
@@ -75,6 +77,12 @@ fun viewMat() = object : ViewMat {
     override fun snapFit(inner: Rect, outer: Rect) {
         val dst = getDst(inner, outer) ?: return
         update { it *= Matrix().apply { setRectToRect(inner, dst) } }
+    }
+
+    override fun setOriginalScale(defaultRegion: Rect, outer: Rect) {
+        val dst = getDst(defaultRegion, outer) ?: return
+        val matrix = Matrix().apply { setRectToRect(defaultRegion, dst) }
+        originalScale = matrix.values[Matrix.ScaleX]
     }
 
     private fun getDst(inner: Rect, outer: Rect): Rect? {

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ZoomLimits.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ZoomLimits.kt
@@ -14,9 +14,9 @@ class ZoomLimits(
         val imageAspectRatio = originalImageSize.width.toFloat() / originalImageSize.height
 
         val fullImageSize = if (viewAspectRatio > imageAspectRatio) {
-            originalImageSize.height
+            originalImageSize.height.coerceAtLeast(view.height)
         } else {
-            originalImageSize.width
+            originalImageSize.width.coerceAtLeast(view.width)
         }.toFloat()
 
         maxFactor = fullImageSize / minCropSize

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ZoomLimits.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/ZoomLimits.kt
@@ -1,0 +1,24 @@
+package com.attafitamim.krop.core.utils
+
+import androidx.compose.ui.unit.IntSize
+
+class ZoomLimits(
+    originalImageSize: IntSize,
+    view: IntSize,
+    val minCropSize: Int = 50, // TODO make this a CropperStyle parameter
+) {
+    val maxFactor: Float
+
+    init {
+        val viewAspectRatio = view.width.toFloat() / view.height
+        val imageAspectRatio = originalImageSize.width.toFloat() / originalImageSize.height
+
+        val fullImageSize = if (viewAspectRatio > imageAspectRatio) {
+            originalImageSize.height
+        } else {
+            originalImageSize.width
+        }.toFloat()
+
+        maxFactor = fullImageSize / minCropSize
+    }
+}

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -27,6 +27,7 @@ import com.attafitamim.krop.core.crop.asMatrix
 import com.attafitamim.krop.core.crop.cropperTouch
 import com.attafitamim.krop.core.images.rememberLoadedImage
 import com.attafitamim.krop.core.utils.ViewMat
+import com.attafitamim.krop.core.utils.ZoomLimits
 import com.attafitamim.krop.core.utils.times
 import com.attafitamim.krop.core.utils.viewMat
 import kotlinx.coroutines.delay
@@ -49,6 +50,9 @@ fun CropperPreview(
         viewMat.matrix.map(state.region)
     }
     val cropPath = remember(state.shape, cropRect) { state.shape.asPath(cropRect) }
+    val zoomLimits = remember(state.src.size, view) {
+        ZoomLimits(state.src.size, view)
+    }
     BringToView(
         enabled = style.autoZoom,
         hasOverride = pendingDrag != null,

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -109,9 +109,9 @@ fun BringToView(
         else {
             if (overrideBlock) {
                 delay(500)
-                overrideBlock = false
             }
             mat.fit(mat.matrix.map(local), outer)
+            overrideBlock = false
         }
     }
 }

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -71,6 +71,7 @@ fun CropperPreview(
                 viewMat = viewMat,
                 pending = pendingDrag,
                 onPending = { pendingDrag = it },
+                zoomLimits = zoomLimits,
             )
     ) {
         withTransform({ transform(totalMat) }) {

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -58,6 +58,7 @@ fun CropperPreview(
         hasOverride = pendingDrag != null,
         outer = view.toSize().toRect().deflate(viewPadding),
         mat = viewMat, local = state.region,
+        transform = state.transform,
     )
     Canvas(
         modifier = modifier
@@ -96,6 +97,7 @@ fun BringToView(
     outer: Rect,
     mat: ViewMat,
     local: Rect
+    transform: ImgTransform,
 ) {
     if (outer.isEmpty) return
     DisposableEffect(Unit) {
@@ -104,7 +106,11 @@ fun BringToView(
     }
     if (!enabled) return
     var overrideBlock by remember { mutableStateOf(false) }
+    LaunchedEffect(outer, transform) { // device rotation
+        mat.setOriginalScale(defaultRegion.applyTransformation(transform), outer)
+    }
     LaunchedEffect(hasOverride, outer, local) {
+
         if (hasOverride) overrideBlock = true
         else {
             if (overrideBlock) {

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/CropperPreview.kt
@@ -43,6 +43,7 @@ fun CropperPreview(
     val viewMat = remember { viewMat() }
     var view by remember { mutableStateOf(IntSize.Zero) }
     var pendingDrag by remember { mutableStateOf<DragHandle?>(null) }
+    val zooming = remember { mutableStateOf(false) }
     val viewPadding = LocalDensity.current.run { style.touchRad.toPx() }
     val totalMat = remember(viewMat.matrix, imgMat) { imgMat * viewMat.matrix }
     val image = rememberLoadedImage(state.src, view, totalMat)
@@ -71,6 +72,7 @@ fun CropperPreview(
                 viewMat = viewMat,
                 pending = pendingDrag,
                 onPending = { pendingDrag = it },
+                zooming = zooming,
                 zoomLimits = zoomLimits,
             )
     ) {

--- a/library/ui/src/desktopTest/kotlin/com/attafitamim/krop/ui/CropStateTest.kt
+++ b/library/ui/src/desktopTest/kotlin/com/attafitamim/krop/ui/CropStateTest.kt
@@ -44,7 +44,7 @@ class CropStateTest {
     fun `Region is inside image rect after resize`() {
         state.region = state.region
             .scale(.5f, .5f)
-            .resize(Offset(1f, 1f), Offset(size.width * 2f, size.height * 2f))
+            .resize(Offset(1f, 1f), Offset(size.width * 2f, size.height * 2f), 10)
         assertRegionInImageRect()
     }
 
@@ -65,7 +65,7 @@ class CropStateTest {
 
     private fun Rect.transformCropRect(): Rect {
         return scale(.5f, .5f)
-            .resize(Offset(1f, 1f), Offset(size.width * 2f, size.height * 2f))
+            .resize(Offset(1f, 1f), Offset(size.width * 2f, size.height * 2f), 10)
     }
 
     private fun assertRegionInImageRect() {


### PR DESCRIPTION
Various zooming improvements:
- **Limit crop size**: `minCropSize` is the minimum size of a crop square
- **Limit zooming in**: zoom is limited accordingly to `minCropSize` (a bit further is allowed)
- **Limit zooming out**: don't allow zooming out further than the original zoom level (was a bit tricky due to device rotation and image rotation)
- **Fix issue**: zooming immediately after cropping causes the screen to snap to the crop window during the zooming: disabled this behaviour to avoid interrupting user action

Best reviewed commit per commit

Tested on android/iphone emulator and android phone