### PR TITLE
Fix issue with first touch event

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Kotlin
 kotlin = "2.0.20"
-kotlin-coroutines = "1.8.1"
+kotlin-coroutines = "1.9.0"
 kotlin-jvm-target = "17"
 
 # Compose

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
@@ -103,16 +103,15 @@ private data class GestureData(
 
 
 fun Modifier.onGestures(state: GestureState): Modifier {
+    var info = GestureData()
     return pointerInput(Unit) {
         coroutineScope {
-            var info = GestureData()
             launch {
-                detectTapGestures(
+                detectTapGestures( // Note: currently unused
                     onLongPress = { state.tap.onLongPress(it.x, it.y, info.maxPointers) },
                     onTap = { state.tap.onTap(it.x, it.y, info.maxPointers) },
                 )
             }
-            launch {
                 detectTransformGestures(panZoomLock = true) { c, _, zoom, _ ->
                     if (!(info.isDrag || info.isZoom)) {
                         if (info.pointers == 1) {
@@ -135,8 +134,8 @@ fun Modifier.onGestures(state: GestureState): Modifier {
                     }
                 }
             }
-            launch {
-                awaitEachGesture {
+    }.pointerInput(Unit) {
+                    awaitEachGesture {
                         info = GestureData()
                         val first = awaitFirstDown(requireUnconsumed = false)
                         info.dragId = first.id
@@ -165,8 +164,6 @@ fun Modifier.onGestures(state: GestureState): Modifier {
                         }
                         if (info.isDrag) state.drag.onDone()
                         if (info.isZoom) state.zoom.onDone()
-                    }
-            }
         }
     }
 }

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
@@ -1,9 +1,9 @@
 package com.attafitamim.krop.core.utils
 
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.gestures.forEachGesture
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
@@ -136,8 +136,7 @@ fun Modifier.onGestures(state: GestureState): Modifier {
                 }
             }
             launch {
-                forEachGesture {
-                    awaitPointerEventScope {
+                awaitEachGesture {
                         info = GestureData()
                         val first = awaitFirstDown(requireUnconsumed = false)
                         info.dragId = first.id
@@ -167,7 +166,6 @@ fun Modifier.onGestures(state: GestureState): Modifier {
                         if (info.isDrag) state.drag.onDone()
                         if (info.isZoom) state.zoom.onDone()
                     }
-                }
             }
         }
     }

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/GestureState.kt
@@ -112,58 +112,58 @@ fun Modifier.onGestures(state: GestureState): Modifier {
                     onTap = { state.tap.onTap(it.x, it.y, info.maxPointers) },
                 )
             }
-                detectTransformGestures(panZoomLock = true) { c, _, zoom, _ ->
-                    if (!(info.isDrag || info.isZoom)) {
-                        if (info.pointers == 1) {
-                            state.drag.onBegin(info.firstPos.x, info.firstPos.y)
-                            info.pos = info.firstPos
-                            info.isDrag = true
-                        } else if (info.pointers > 1) {
-                            state.zoom.onBegin(c.x, c.y)
-                            info.isZoom = true
-                        }
+            detectTransformGestures(panZoomLock = true) { c, _, zoom, _ ->
+                if (!(info.isDrag || info.isZoom)) {
+                    if (info.pointers == 1) {
+                        state.drag.onBegin(info.firstPos.x, info.firstPos.y)
+                        info.pos = info.firstPos
+                        info.isDrag = true
+                    } else if (info.pointers > 1) {
+                        state.zoom.onBegin(c.x, c.y)
+                        info.isZoom = true
                     }
-                    if (info.isDrag) {
-                        state.drag.onNext(
-                            info.nextPos.x - info.pos.x, info.nextPos.y - info.pos.y,
-                            info.nextPos.x, info.nextPos.y, info.pointers
-                        )
+                }
+                if (info.isDrag) {
+                    state.drag.onNext(
+                        info.nextPos.x - info.pos.x, info.nextPos.y - info.pos.y,
+                        info.nextPos.x, info.nextPos.y, info.pointers
+                    )
+                    info.pos = info.nextPos
+                } else if (info.isZoom) {
+                    if (zoom != 1f) state.zoom.onNext(zoom, c.x, c.y)
+                }
+            }
+        }
+    }.pointerInput(Unit) {
+        awaitEachGesture {
+            info = GestureData()
+            val first = awaitFirstDown(requireUnconsumed = false)
+            info.dragId = first.id
+            info.firstPos = first.position
+            info.pointers = 1
+            info.maxPointers = 1
+            var event: PointerEvent
+            while (info.pointers > 0) {
+                event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                var dragPointer: PointerInputChange? = null
+                for (change in event.changes) {
+                    if (change.changedToDown()) info.pointers++
+                    else if (change.changedToUp()) info.pointers--
+                    info.maxPointers = max(info.maxPointers, info.pointers)
+                    if (change.id == info.dragId) dragPointer = change
+                }
+                if (dragPointer == null) dragPointer =
+                    event.changes.firstOrNull { it.pressed }
+                if (dragPointer != null) {
+                    info.nextPos = dragPointer.position
+                    if (info.dragId != dragPointer.id) {
                         info.pos = info.nextPos
-                    } else if (info.isZoom) {
-                        if (zoom != 1f) state.zoom.onNext(zoom, c.x, c.y)
+                        info.dragId = dragPointer.id
                     }
                 }
             }
-    }.pointerInput(Unit) {
-                    awaitEachGesture {
-                        info = GestureData()
-                        val first = awaitFirstDown(requireUnconsumed = false)
-                        info.dragId = first.id
-                        info.firstPos = first.position
-                        info.pointers = 1
-                        info.maxPointers = 1
-                        var event: PointerEvent
-                        while (info.pointers > 0) {
-                            event = awaitPointerEvent(pass = PointerEventPass.Initial)
-                            var dragPointer: PointerInputChange? = null
-                            for (change in event.changes) {
-                                if (change.changedToDown()) info.pointers++
-                                else if (change.changedToUp()) info.pointers--
-                                info.maxPointers = max(info.maxPointers, info.pointers)
-                                if (change.id == info.dragId) dragPointer = change
-                            }
-                            if (dragPointer == null) dragPointer =
-                                event.changes.firstOrNull { it.pressed }
-                            if (dragPointer != null) {
-                                info.nextPos = dragPointer.position
-                                if (info.dragId != dragPointer.id) {
-                                    info.pos = info.nextPos
-                                    info.dragId = dragPointer.id
-                                }
-                            }
-                        }
-                        if (info.isDrag) state.drag.onDone()
-                        if (info.isZoom) state.zoom.onDone()
+            if (info.isDrag) state.drag.onDone()
+            if (info.isZoom) state.zoom.onDone()
         }
     }
 }


### PR DESCRIPTION
The first touch event did not work: dragging the cropping rectangle or zooming in/out does not work on the first tap.

This PR fixes that issue.

I am not exactly sure why it is fixed now, it took quite some debugging. I guess there is some race condition in the coroutines between the different gesture detection methods: e.g. the `awaitFirstDown` event did not fire for the first tap.

Feel free to experiment a bit as well with the code

Best reviewed commit per commit due to linting at the end.

I also had an IDE issue (Android Studio) with Kotlin coroutines, and noticed Coroutines 1.9 is out of beta, so upgraded that library.

@tamimattafi In case you are wondering how many more PRs I'm gonna make, this is the last issue on my list 😅 (apart from https://github.com/tamimattafi/krop/issues/9)