### PR TITLE
Fix: maxSize ignored when clipping shape on save

### DIFF
--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
@@ -40,7 +40,7 @@ suspend fun CropState.doCreateResult(maxSize: IntSize?): ImageBitmap? {
     val imgMat = transform.asMatrix(src.size)
     val totalMat = imgMat * viewMat.matrix
 
-    canvas.clipPath(shape.asPath(region.atOrigin()))
+    canvas.clipPath(shape.asPath(region.atOrigin(maxSize)))
     canvas.concat(totalMat)
     val inParams = getDecodeParams(view = finalSize, img = src.size, totalMat)
         ?: return null

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/utils/Rect.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toSize
 import com.attafitamim.krop.core.crop.AspectRatio
 import kotlin.math.absoluteValue
 import kotlin.math.ceil
@@ -28,7 +29,10 @@ fun Size.coerceAtMost(maxSize: Size): Size {
     return Size(width = width * scaleF, height = height * scaleF)
 }
 
-fun Rect.atOrigin(): Rect = Rect(offset = Offset.Zero, size = size)
+fun Rect.atOrigin(maxSize: IntSize?): Rect = Rect(
+    offset = Offset.Zero,
+    size = maxSize?.let { size.coerceAtMost(it.toSize()) } ?: size
+)
 
 val Rect.area get() = width * height
 


### PR DESCRIPTION
Fix: maxSize was not considered when clipping the path of a shape: if a `maxResultSize` was passed lower than the image size, the clipping was incorrect

Example image (1200 px, `maxResultSize = IntSize(300, 300)`):

| Image | Old result | Fixed result |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/f50b2212-2c5f-4480-b939-7f1a0fdf78a9" width="200"  /> | <img src="https://github.com/user-attachments/assets/e0b3a1ed-2a08-481b-8b8b-fb64d951f7a5" width="200"  /> | <img src="https://github.com/user-attachments/assets/0f5eac77-fd80-49f6-a795-497fa211b26b" width="200"  /> |