### PR TITLE
fix: bug where the default shape is fixed to Rect, use the first shape of the list of shapes instead

### DIFF
--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropperStyle.kt
@@ -45,7 +45,7 @@ interface CropperStyle {
     val touchRad: Dp
 
     /** All available crop shapes */
-    val shapes: List<CropShape>?
+    val shapes: List<CropShape>
 
     /** All available aspect ratios */
     val aspects: List<AspectRatio>
@@ -86,14 +86,14 @@ fun cropperStyle(
     guidelines: CropperStyleGuidelines? = CropperStyleGuidelines(),
     secondaryHandles: Boolean = true,
     overlay: Color = Color.Black.copy(alpha = .5f),
-    shapes: List<CropShape>? = DefaultCropShapes,
+    shapes: List<CropShape> = DefaultCropShapes,
     aspects: List<AspectRatio> = DefaultAspectRatios,
     autoZoom: Boolean = true,
 ): CropperStyle = object : CropperStyle {
     override val touchRad: Dp get() = touchRad
     override val backgroundColor: Color get() = backgroundColor
     override val overlayColor: Color get() = overlay
-    override val shapes: List<CropShape>? get() = shapes?.takeIf { it.isNotEmpty() }
+    override val shapes: List<CropShape> get() = shapes
     override val aspects get() = aspects
     override val autoZoom: Boolean get() = autoZoom
 

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
@@ -64,7 +64,7 @@ val LocalVerticalControls = staticCompositionLocalOf { false }
 fun CropperControls(
     isVertical: Boolean,
     state: CropState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     CompositionLocalProvider(LocalVerticalControls provides isVertical) {
         ButtonsBar(modifier = modifier) {
@@ -82,35 +82,35 @@ fun CropperControls(
             }
             LocalCropperStyle.current.aspects.let { aspects ->
                 if (aspects.size > 1) {
-            Box {
-                var menu by remember { mutableStateOf(false) }
-                IconButton(onClick = { menu = !menu }) {
-                    Icon(painterResource(Res.drawable.resize), null)
-                }
-                if (menu) AspectSelectionMenu(
-                    onDismiss = { menu = false },
-                    region = state.region,
-                    onRegion = { state.region = it },
-                    lock = state.aspectLock,
-                    onLock = { state.aspectLock = it }
-                )
-            }
+                    Box {
+                        var menu by remember { mutableStateOf(false) }
+                        IconButton(onClick = { menu = !menu }) {
+                            Icon(painterResource(Res.drawable.resize), null)
+                        }
+                        if (menu) AspectSelectionMenu(
+                            onDismiss = { menu = false },
+                            region = state.region,
+                            onRegion = { state.region = it },
+                            lock = state.aspectLock,
+                            onLock = { state.aspectLock = it }
+                        )
+                    }
                 }
             }
             LocalCropperStyle.current.shapes.let { shapes ->
                 if (shapes.size > 1) {
-                Box {
-                    var menu by remember { mutableStateOf(false) }
-                    IconButton(onClick = { menu = !menu }) {
-                        Icon(Icons.Default.Star, null)
+                    Box {
+                        var menu by remember { mutableStateOf(false) }
+                        IconButton(onClick = { menu = !menu }) {
+                            Icon(Icons.Default.Star, null)
+                        }
+                        if (menu) ShapeSelectionMenu(
+                            onDismiss = { menu = false },
+                            selected = state.shape,
+                            onSelect = { state.shape = it },
+                            shapes = shapes
+                        )
                     }
-                    if (menu) ShapeSelectionMenu(
-                        onDismiss = { menu = false },
-                        selected = state.shape,
-                        onSelect = { state.shape = it },
-                        shapes = shapes
-                    )
-                }
                 }
             }
         }
@@ -120,7 +120,7 @@ fun CropperControls(
 @Composable
 fun ButtonsBar(
     modifier: Modifier = Modifier,
-    buttons: @Composable () -> Unit
+    buttons: @Composable () -> Unit,
 ) {
     Surface(
         modifier = modifier,
@@ -144,7 +144,6 @@ fun ButtonsBar(
 }
 
 
-
 @Composable
 fun ShapeSelectionMenu(
     onDismiss: () -> Unit,
@@ -163,7 +162,7 @@ fun ShapeSelectionMenu(
 @Composable
 fun ShapeItem(
     shape: CropShape, selected: Boolean, onSelect: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val color by animateColorAsState(
         targetValue = if (!selected) LocalContentColor.current
@@ -193,7 +192,7 @@ fun AspectSelectionMenu(
     region: Rect,
     onRegion: (Rect) -> Unit,
     lock: Boolean,
-    onLock: (Boolean) -> Unit
+    onLock: (Boolean) -> Unit,
 ) {
     val aspects = LocalCropperStyle.current.aspects
     OptionsPopup(onDismiss = onDismiss, optionCount = 1 + aspects.size) { i ->

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
@@ -93,7 +93,7 @@ fun CropperControls(
                     onLock = { state.aspectLock = it }
                 )
             }
-            LocalCropperStyle.current.shapes?.let { shapes ->
+            LocalCropperStyle.current.shapes.let { shapes ->
                 Box {
                     var menu by remember { mutableStateOf(false) }
                     IconButton(onClick = { menu = !menu }) {

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/Controls.kt
@@ -80,6 +80,8 @@ fun CropperControls(
             IconButton(onClick = { state.flipVertical() }) {
                 Icon(painterResource(Res.drawable.flip_ver), null)
             }
+            LocalCropperStyle.current.aspects.let { aspects ->
+                if (aspects.size > 1) {
             Box {
                 var menu by remember { mutableStateOf(false) }
                 IconButton(onClick = { menu = !menu }) {
@@ -93,7 +95,10 @@ fun CropperControls(
                     onLock = { state.aspectLock = it }
                 )
             }
+                }
+            }
             LocalCropperStyle.current.shapes.let { shapes ->
+                if (shapes.size > 1) {
                 Box {
                     var menu by remember { mutableStateOf(false) }
                     IconButton(onClick = { menu = !menu }) {
@@ -105,6 +110,7 @@ fun CropperControls(
                         onSelect = { state.shape = it },
                         shapes = shapes
                     )
+                }
                 }
             }
         }

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -50,6 +51,10 @@ fun ImageCropperDialog(
     topBar: @Composable (CropState) -> Unit = { DefaultTopBar(it) },
     cropControls: @Composable BoxScope.(CropState) -> Unit = { DefaultControls(it) }
 ) {
+    LaunchedEffect(Unit) {
+        state.setInitialState(style) // Could be buggy, since it is run in a separate thread
+    }
+
     CompositionLocalProvider(LocalCropperStyle provides style) {
         Dialog(
             onDismissRequest = { state.done(accept = false) },

--- a/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
+++ b/library/ui/src/commonMain/kotlin/com/attafitamim/krop/ui/ImageCropperDialog.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -92,7 +92,7 @@ fun DefaultTopBar(state: CropState) {
     TopAppBar(title = {},
         navigationIcon = {
             IconButton(onClick = { state.done(accept = false) }) {
-                Icon(Icons.Default.ArrowBack, null)
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
             }
         },
         actions = {

--- a/sample/composeApp/src/commonMain/kotlin/com/attafitamim/krop/sample/ui/DemoContent.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/attafitamim/krop/sample/ui/DemoContent.kt
@@ -11,8 +11,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.dp
+import com.attafitamim.krop.core.crop.AspectRatio
+import com.attafitamim.krop.core.crop.CircleCropShape
 import com.attafitamim.krop.core.crop.CropState
 import com.attafitamim.krop.core.crop.CropperLoading
+import com.attafitamim.krop.core.crop.RectCropShape
+import com.attafitamim.krop.core.crop.StarCropShape
+import com.attafitamim.krop.core.crop.TriangleCropShape
+import com.attafitamim.krop.core.crop.cropperStyle
 import com.attafitamim.krop.sample.ui.theme.KropTheme
 import com.attafitamim.krop.ui.ImageCropperDialog
 
@@ -26,7 +32,13 @@ fun DemoContent(
 ) {
     if (cropState != null) {
         KropTheme(darkTheme = true) {
-            ImageCropperDialog(state = cropState)
+            ImageCropperDialog(
+                state = cropState,
+                style = cropperStyle(
+                    shapes = listOf(RectCropShape, CircleCropShape, TriangleCropShape, StarCropShape),
+                    aspects = listOf(AspectRatio(16, 9), AspectRatio(1, 1)),
+                )
+            )
         }
     }
     if (cropState == null && loadingStatus != null) {


### PR DESCRIPTION
- Fix bug where the default shape is fixed to Rect, use the first shape of the list of shapes instead

CropperStyle Shapes:
- More than 1 shape passed: the first one is the default
- 1 shape passed: that shape is always used, control disappears
- 0 shapes passed: fallback to Rect

CropperStyle Aspect Ratios:
- More than 1 AR passed: the first one is the default
- 1 AR passed: always used, control disappears, AR is locked
- 0 ARs passed: no control, not locked
