### PR TITLE
feat: add Compose Desktop example

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ android-gradle-plugin = "8.3.2"
 android-activity-compose = "1.9.2"
 androidx_lifecycle = "2.8.6"
 android-test-runner = "1.6.2"
+androidx-collection = "1.4.5"
 
 # Publishing
 maven-publish = "0.29.0"
@@ -19,9 +20,11 @@ maven-publish = "0.29.0"
 # Testing
 junit = "4.13.2"
 android-exif = "1.3.7"
+metadata-extractor = "2.19.0"
 
 [libraries]
 # Kotlin
+androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # Android
@@ -29,6 +32,7 @@ android-build-tools = { module = "com.android.tools.build:gradle", version.ref =
 android-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "android-activity-compose" }
 android-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx_lifecycle" }
 android-lifecycle-view-model = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx_lifecycle" }
+kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlin-coroutines" }
 
 # Publish
 maven-publish-plugin = { module = "com.vanniktech.maven.publish.base:com.vanniktech.maven.publish.base.gradle.plugin", version.ref = "maven-publish" }
@@ -38,6 +42,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 android-test-runner = { module = "androidx.test:runner", version.ref = "android-test-runner" }
 android-exif = { module = "androidx.exifinterface:exifinterface", version.ref = "android-exif" }
+metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadata-extractor" }
 
 
 [plugins]

--- a/library/core/build.gradle.kts
+++ b/library/core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 kotlin {
+    jvm("desktop")
     sourceSets {
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -16,6 +17,13 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.android.exif)
+        }
+
+        val desktopMain by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(libs.metadata.extractor)
+            }
         }
     }
 }

--- a/library/core/build.gradle.kts
+++ b/library/core/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 kotlin {
-    jvm("desktop")
     sourceSets {
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageOrientation.kt
+++ b/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageOrientation.kt
@@ -1,0 +1,15 @@
+package com.attafitamim.krop.core.images
+
+/**
+ * Constants for EXIF orientation values.
+ */
+object ImageOrientation {
+    const val NORMAL = 1
+    const val FLIP_HORIZONTAL = 2
+    const val ROTATE_180 = 3
+    const val FLIP_VERTICAL = 4
+    const val ROTATE_90_CW_FLIP_HORIZONTAL = 5
+    const val ROTATE_90_CW = 6
+    const val ROTATE_90_CCW_FLIP_HORIZONTAL = 7
+    const val ROTATE_90_CCW = 8
+}

--- a/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStream.desktop.kt
+++ b/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStream.desktop.kt
@@ -14,4 +14,4 @@ class FileImageStream(private val file: File) : ImageStream {
 }
 
 @Throws(IOException::class, NullPointerException::class)
-suspend fun File.toImageSrc() = DesktopImageStreamSrc(FileImageStream(this))
+suspend fun File.toImageSrc() = ImageStreamSrc(FileImageStream(this))

--- a/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStream.desktop.kt
+++ b/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStream.desktop.kt
@@ -1,0 +1,17 @@
+package com.attafitamim.krop.core.images
+
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+
+interface ImageStream {
+    @Throws(IOException::class, NullPointerException::class)
+    suspend fun openStream(): InputStream?
+}
+
+class FileImageStream(private val file: File) : ImageStream {
+    override suspend fun openStream(): InputStream = file.inputStream()
+}
+
+@Throws(IOException::class, NullPointerException::class)
+suspend fun File.toImageSrc() = DesktopImageStreamSrc(FileImageStream(this))

--- a/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStreamSrc.desktop.kt
+++ b/library/core/src/desktopMain/kotlin/com/attafitamim/krop/core/images/ImageStreamSrc.desktop.kt
@@ -1,0 +1,292 @@
+package com.attafitamim.krop.core.images
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toIntRect
+import com.drew.imaging.ImageMetadataReader
+import com.drew.metadata.Metadata
+import com.drew.metadata.bmp.BmpHeaderDirectory
+import com.drew.metadata.exif.ExifIFD0Directory
+import com.drew.metadata.file.FileTypeDirectory
+import com.drew.metadata.gif.GifImageDirectory
+import com.drew.metadata.ico.IcoDirectory
+import com.drew.metadata.jpeg.JpegDirectory
+import com.drew.metadata.png.PngDirectory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.Image
+import java.awt.geom.AffineTransform
+import java.awt.image.BufferedImage
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.imageio.ImageIO
+import javax.imageio.ImageReader
+
+
+data class DesktopImageStreamSrc(
+    private val dataSource: ImageStream,
+    override val size: IntSize
+) : ImageSrc {
+    private val allowRegion = AtomicBoolean(false)
+
+    /**
+     * Opens image region with specified sample size and orientation
+     * @param params DecodeParams containing sample size and region to decode
+     * @return DecodeResult containing the processed image
+     */
+    private suspend fun openRegion(params: DecodeParams): DecodeResult? {
+        return dataSource.use { stream ->
+            getImageReader(stream)?.decodeRegion(params)
+        }?.let { bufferedImage ->
+            DecodeResult(params, bufferedImage.toImageBitmap())
+        }
+    }
+
+    /**
+     * Opens full image with specified sample size and orientation
+     * @param sampleSize downscaling factor
+     * @param orientation EXIF orientation value
+     * @return DecodeResult containing the processed image
+     */
+    private suspend fun openFull(sampleSize: Int, orientation: Int): DecodeResult? {
+        return dataSource.use { stream ->
+            getImageReader(stream)?.decodeFull(sampleSize)?.ensureCorrectOrientation(orientation)
+        }?.let { bmp ->
+            DecodeResult(DecodeParams(sampleSize, size.toIntRect()), bmp.toImageBitmap())
+        }
+    }
+
+    override suspend fun open(params: DecodeParams): DecodeResult? {
+        val orientation = dataSource.getOrientation()
+        if (!isImageSizeFlipped(orientation) && allowRegion.get()) {
+            val region = openRegion(params)
+            if (region != null) return region
+            else allowRegion.set(false)
+        }
+
+        return openFull(params.sampleSize, orientation)
+    }
+
+    companion object {
+        suspend operator fun invoke(dataSource: ImageStream): DesktopImageStreamSrc? {
+            val size = dataSource.getImageSize()
+                ?.takeIf { it.width > 0 && it.height > 0 }
+                ?: return null
+            return DesktopImageStreamSrc(dataSource, size)
+        }
+    }
+}
+
+private suspend fun <R> ImageStream.use(op: suspend (InputStream) -> R): R? {
+    return withContext(Dispatchers.IO) {
+        try {
+            openStream()?.use { stream -> op(stream) }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+}
+
+private fun getImageReader(stream: InputStream): ImageReader? {
+    val imageInputStream = ImageIO.createImageInputStream(stream)
+    val readers = ImageIO.getImageReaders(imageInputStream)
+    return if (readers.hasNext()) readers.next().apply { input = imageInputStream } else null
+}
+
+private fun ImageReader.decodeRegion(params: DecodeParams): BufferedImage? {
+    val rect = params.subset
+    return try {
+        val param = defaultReadParam
+        param.sourceRegion = java.awt.Rectangle(
+            rect.left, rect.top, rect.width, rect.height
+        )
+        param.setSourceSubsampling(params.sampleSize, params.sampleSize, 0, 0)
+        read(0, param)
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}
+
+private fun ImageReader.decodeFull(sampleSize: Int) = try {
+    val param = defaultReadParam
+    param.setSourceSubsampling(sampleSize, sampleSize, 0, 0)
+    read(0, param)
+} catch (e: Exception) {
+    e.printStackTrace()
+    null
+}
+
+suspend fun ImageStream.getOrientation(): Int {
+    return use { stream ->
+        val metadata = ImageMetadataReader.readMetadata(stream)
+        metadata.getOrientation()
+    } ?: 1 // normal orientation by default
+}
+
+/**
+ * Get image size. The method will try to read image metadata to get the image size first, if failed, it will
+ * try to read image data to get the result.
+ *
+ * @return image size or null if failed to get
+ */
+suspend fun ImageStream.getImageSize(): IntSize? = use { stream ->
+    try {
+        val metadata = ImageMetadataReader.readMetadata(stream)
+        // read file extension from metadata
+        val fileTypeDirectory = metadata.getFirstDirectoryOfType(FileTypeDirectory::class.java)
+        val fileExt = fileTypeDirectory?.getString(FileTypeDirectory.TAG_EXPECTED_FILE_NAME_EXTENSION)
+
+        var width: Int? = null
+        var height: Int? = null
+
+        when (fileExt) {
+            "jpg", "jpeg" -> {
+                val jpegDirectory = metadata.getFirstDirectoryOfType(JpegDirectory::class.java)
+                width = jpegDirectory?.getInt(JpegDirectory.TAG_IMAGE_WIDTH)
+                height = jpegDirectory?.getInt(JpegDirectory.TAG_IMAGE_HEIGHT)
+            }
+            "png" -> {
+                val pngDirectory = metadata.getFirstDirectoryOfType(PngDirectory::class.java)
+                width = pngDirectory?.getInt(PngDirectory.TAG_IMAGE_WIDTH)
+                height = pngDirectory?.getInt(PngDirectory.TAG_IMAGE_HEIGHT)
+            }
+            "gif" -> {
+                val gifDirectory = metadata.getFirstDirectoryOfType(GifImageDirectory::class.java)
+                width = gifDirectory?.getInt(GifImageDirectory.TAG_WIDTH)
+                height = gifDirectory?.getInt(GifImageDirectory.TAG_HEIGHT)
+            }
+            "bmp" -> {
+                val bmpDirectory = metadata.getFirstDirectoryOfType(BmpHeaderDirectory::class.java)
+                width = bmpDirectory?.getInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH)
+                height = bmpDirectory?.getInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT)
+            }
+            "ico" -> {
+                val icoDirectory = metadata.getFirstDirectoryOfType(IcoDirectory::class.java)
+                width = icoDirectory?.getInt(IcoDirectory.TAG_IMAGE_WIDTH)
+                height = icoDirectory?.getInt(IcoDirectory.TAG_IMAGE_HEIGHT)
+            }
+            else -> { }
+        }
+
+        if (width != null && height != null) {
+            val orientation = metadata.getOrientation()
+            if (isImageSizeFlipped(orientation)) {
+                IntSize(height, width)
+            } else {
+                IntSize(width, height)
+            }
+        } else {
+            // Fallback to ImageIO if EXIF data is not available
+            stream.reset()
+            val reader = getImageReader(stream) ?: return@use null
+
+            try {
+                width = reader.getWidth(0)
+                height = reader.getHeight(0)
+                val orientation = metadata.getOrientation()
+
+                if (isImageSizeFlipped(orientation)) {
+                    IntSize(height, width)
+                } else {
+                    IntSize(width, height)
+                }
+            } finally {
+                reader.dispose()
+            }
+        }
+    } catch (e: Exception) {
+        null
+    }
+}
+
+private fun BufferedImage.toImageBitmap(): ImageBitmap {
+    // convert BufferedImage to byte array
+    val baos = java.io.ByteArrayOutputStream()
+    ImageIO.write(this, "png", baos)
+    val bytes = baos.toByteArray()
+
+    // create ImageBitmap from byte array by Skia
+    return Image.makeFromEncoded(bytes).toComposeImageBitmap()
+}
+
+private fun BufferedImage.ensureCorrectOrientation(orientation: Int): BufferedImage {
+    if (orientation == 1) return this
+
+    val transform = AffineTransform()
+    val width = width.toDouble()
+    val height = height.toDouble()
+
+    when (orientation) {
+        2 -> { // Flip horizontal
+            transform.translate(width, 0.0)
+            transform.scale(-1.0, 1.0)
+        }
+        3 -> { // Rotate 180°
+            transform.translate(width, height)
+            transform.rotate(Math.PI)
+        }
+        4 -> { // Flip vertical
+            transform.translate(0.0, height)
+            transform.scale(1.0, -1.0)
+        }
+        5 -> { // Rotate 90° CW and flip horizontal
+            transform.rotate(0.5 * Math.PI)
+            transform.scale(-1.0, 1.0)
+        }
+        6 -> { // Rotate 90° CW
+            transform.translate(height, 0.0)
+            transform.rotate(0.5 * Math.PI)
+        }
+        7 -> { // Rotate 90° CCW and flip horizontal
+            transform.scale(-1.0, 1.0)
+            transform.translate(-height, 0.0)
+            transform.translate(0.0, width)
+            transform.rotate(-0.5 * Math.PI)
+        }
+        8 -> { // Rotate 90° CCW
+            transform.translate(0.0, width)
+            transform.rotate(-0.5 * Math.PI)
+        }
+    }
+
+    val destinationType = if (type == BufferedImage.TYPE_CUSTOM) {
+        BufferedImage.TYPE_INT_ARGB
+    } else {
+        type
+    }
+
+    // Calculate destination dimensions based on orientation
+    val destinationWidth = if (orientation in 5..8) height.toInt() else width.toInt()
+    val destinationHeight = if (orientation in 5..8) width.toInt() else height.toInt()
+
+    val destinationImage = BufferedImage(destinationWidth, destinationHeight, destinationType)
+    val graphics = destinationImage.createGraphics()
+
+    try {
+        graphics.transform(transform)
+        graphics.drawImage(this, 0, 0, null)
+        return destinationImage
+    } finally {
+        graphics.dispose()
+    }
+}
+
+/**
+ * Checks if the image dimensions should be flipped based on EXIF orientation
+ * @param orientation EXIF orientation value
+ * @return true if width and height should be swapped
+ */
+private fun isImageSizeFlipped(orientation: Int): Boolean {
+    return when (orientation) {
+        5, 6, 7, 8 -> true // These orientations involve 90° or 270° rotation
+        else -> false
+    }
+}
+
+private fun Metadata.getOrientation(): Int {
+    val directory = getFirstDirectoryOfType(ExifIFD0Directory::class.java)
+    return directory?.getInt(ExifIFD0Directory.TAG_ORIENTATION) ?: 1
+}

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.application)
@@ -16,6 +18,8 @@ kotlin {
             }
         }
     }
+
+    jvm("desktop")
     
     listOf(
         iosX64(),
@@ -49,6 +53,14 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.android.activity.compose)
+        }
+
+        val desktopMain by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(libs.kotlinx.coroutines.swing)
+                implementation(libs.androidx.collection)
+            }
         }
     }
 }
@@ -95,3 +107,14 @@ android {
     }
 }
 
+compose.desktop {
+    application {
+        mainClass = "com.attafitamim.krop.sample.MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "com.attafitamim.krop"
+            packageVersion = "1.0.0"
+        }
+    }
+}

--- a/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/Main.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/Main.kt
@@ -1,0 +1,21 @@
+package com.attafitamim.krop.sample
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import com.attafitamim.krop.sample.presentation.ImagesViewModel
+import com.attafitamim.krop.sample.ui.App
+
+fun main() {
+    application {
+        Window(
+            title = "Krop Sample",
+            onCloseRequest = ::exitApplication
+        ) {
+            /**
+             * To simplify the sample, we are just initializing the ViewModel as a normal object here.
+             */
+            val viewModel = ImagesViewModel()
+            App(viewModel)
+        }
+    }
+}

--- a/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/Main.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/Main.kt
@@ -1,5 +1,6 @@
 package com.attafitamim.krop.sample
 
+import androidx.compose.runtime.remember
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.attafitamim.krop.sample.presentation.ImagesViewModel
@@ -14,7 +15,7 @@ fun main() {
             /**
              * To simplify the sample, we are just initializing the ViewModel as a normal object here.
              */
-            val viewModel = ImagesViewModel()
+            val viewModel = remember { ImagesViewModel() }
             App(viewModel)
         }
     }

--- a/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/picker/ImagePicker.desktop.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/picker/ImagePicker.desktop.kt
@@ -1,0 +1,74 @@
+package com.attafitamim.krop.sample.picker
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import com.attafitamim.krop.core.images.ImageSrc
+import com.attafitamim.krop.core.images.toImageSrc
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+
+@Composable
+actual fun rememberImagePicker(onImage: (uri: ImageSrc) -> Unit): ImagePicker {
+    val coroutineScope = rememberCoroutineScope()
+    val currentOnImage by rememberUpdatedState(onImage)
+    return remember {
+        DesktopImagePicker { file ->
+            coroutineScope.launch {
+                runCatching { file.toImageSrc() }.getOrNull()?.let { src ->
+                    currentOnImage(src)
+                }
+            }
+        }
+    }
+}
+
+class DesktopImagePicker(
+    private val onFile: suspend (File) -> Unit
+) : ImagePicker {
+    private val userHomePath by lazy { System.getProperty("user.home") }
+    private val fileDialog = FileDialog(null as Frame?, "Select an image", FileDialog.LOAD)
+
+    override fun pick(mimetype: String) {
+        fileDialog.apply {
+            if (directory == null) {
+                directory = userHomePath
+            }
+            setFilenameFilter { _, name ->
+                val lowerCaseName = name.lowercase()
+                val extensions = mimetype.mimeToExtensions()
+                extensions.any {
+                    lowerCaseName.endsWith(it)
+                }
+            }
+            isVisible = true
+
+            file?.let { fileName ->
+                directory?.let { dir ->
+                    val selectedFile = File(dir, fileName)
+                    CoroutineScope(Dispatchers.Main).launch {
+                        onFile(selectedFile)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun String.mimeToExtensions(): Array<String> {
+    return when (this) {
+        "image/jpeg" -> arrayOf("jpg", "jpeg")
+        "image/png" -> arrayOf("png")
+        "image/gif" -> arrayOf("gif")
+        "image/bmp" -> arrayOf("bmp")
+        "image/ico" -> arrayOf("ico")
+        "image/*" -> arrayOf("jpg", "jpeg", "png", "gif", "bmp", "ico")
+        else -> arrayOf()
+    }
+}

--- a/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/picker/ImagePicker.desktop.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/attafitamim/krop/sample/picker/ImagePicker.desktop.kt
@@ -63,12 +63,12 @@ class DesktopImagePicker(
 
 private fun String.mimeToExtensions(): Array<String> {
     return when (this) {
-        "image/jpeg" -> arrayOf("jpg", "jpeg")
+        "image/jpeg" -> arrayOf("jpg", "jpeg", "jfif", "pjpeg", "pjp")
         "image/png" -> arrayOf("png")
         "image/gif" -> arrayOf("gif")
         "image/bmp" -> arrayOf("bmp")
-        "image/ico" -> arrayOf("ico")
-        "image/*" -> arrayOf("jpg", "jpeg", "png", "gif", "bmp", "ico")
+        "image/ico" -> arrayOf("ico", "cur")
+        "image/*" -> arrayOf("jpg", "jpeg", "jfif", "pjpeg", "pjp", "png", "gif", "bmp", "ico", "cur")
         else -> arrayOf()
     }
 }


### PR DESCRIPTION
- Add `ImageStream` and `ImageStreamSrc` of desktop version in module `library:core`
- add corresponding desktop demo in `sample`

The code uses `metadata-extractor` to get the size of an image efficiently, and uses `skia.Image` and `javax.imageio` to deal with image reading and cropping. Most of the code are generated by `Claude 3.5 Sonnet`. I've tested image types like `jpg`, `png`, `bmp`, `ico`, `gif`(non animatable) and it works well. The screenshots are listed below (on Mac OS):

![image](https://github.com/user-attachments/assets/c64c8923-1d44-4601-b2f6-fe99c1c921fb)
![image](https://github.com/user-attachments/assets/b7775dee-ad63-4baf-93cb-f43eec573ab6)
![image](https://github.com/user-attachments/assets/6d8a8635-26b4-4d37-93ac-8c3315e24bb5)
