### PR TITLE
Compose plugin 1.8.0 alpha03 integration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 # Kotlin
-kotlin = "2.0.21"
-kotlin-coroutines = "1.9.0"
+kotlin = "2.1.10"
+kotlin-coroutines = "1.10.1"
 kotlin-jvm-target = "17"
 
 # Compose
-compose_plugin = "1.7.0"
+compose_plugin = "1.8.0-alpha03"
 
 # Android
-android-gradle-plugin = "8.3.2"
+android-gradle-plugin = "8.5.0"
 android-activity-compose = "1.9.2"
 androidx_lifecycle = "2.8.6"
 android-test-runner = "1.6.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 26 12:30:04 GMT+07:00 2024
+#Mon Feb 24 21:37:42 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -67,7 +67,7 @@ kotlin {
 
 android {
     namespace = "com.attafitamim.krop"
-    compileSdk = 34
+    compileSdk = 35
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
@@ -76,7 +76,7 @@ android {
     defaultConfig {
         applicationId = "com.attafitamim.krop"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
Compose plugin version upgrade to 1.8.0 alpha03 to solve https://github.com/tamimattafi/krop/issues/40
This change required a few other changes. After changing it, it seems to be fixing the crash (The Sample app work fine on a simulator)