### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+enable-beta-ecosystems: true
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: all    
+    registries:
+      - maven-central
+      - maven-google
+      - gradle-plugin
+
+# Workaround for https://github.com/dependabot/dependabot-core/issues/6888
+registries:
+  maven-google:
+    type: maven-repository
+    url: "https://dl.google.com/dl/android/maven2/"
+  gradle-plugin:
+    type: maven-repository
+    url: "https://plugins.gradle.org/m2/"
+  maven-central:
+    type: maven-repository
+    url: "https://repo1.maven.org/maven2/"    


### PR DESCRIPTION
Instead of manually bumping library versions as done [here](https://github.com/tamimattafi/krop/pull/67), [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) can create PRs on our behalf updating all library dependencies.