### PR TITLE
Add Gradle Wrapper Updater

### DIFF
--- a/.github/workflows/update_gradle_wrapper.yml
+++ b/.github/workflows/update_gradle_wrapper.yml
@@ -1,0 +1,21 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK 21 (Corretto)
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Hi @tamimattafi, 

In lieu of keeping library's dependencies up to date, thought we'd also keep its Gradle wrapper up to date.

This [Update Gradle Wrapper Action](https://github.com/gradle-update/update-gradle-wrapper-action) does exactly that. It too verifies the integrity of the gradle-wrapper.jar file being updated by comparing its SHA-256 checksum against the official checksum value published by Gradle authors.

Best!