### PR TITLE
Non-destructive cropping: cropRegion(), renderCropRegion() and re-crop seeding

### DIFF
--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/CropState.kt
@@ -41,9 +41,10 @@ interface CropState {
 
 fun cropState(
     src: ImageSrc,
+    initial: CropRegion? = null,
     onDone: () -> Unit = {},
 ): CropState = object : CropState {
-    val defaultTransform: ImgTransform = ImgTransform.Identity
+    val defaultTransform: ImgTransform = initial?.transform ?: ImgTransform.Identity
     private var defaultShape: CropShape = RectCropShape
     private var defaultAspectLock: Boolean = false
     private var defaultClipResultToShape: Boolean = true
@@ -57,9 +58,12 @@ fun cropState(
         }
 
     override val defaultRegion = src.size.toSize().toRect()
-    private var firstRegion: Rect = defaultRegion
+    // When [initial] is supplied the session opens seeded at that crop (re-crop
+    // "where you left off") instead of the full-image / style-aspect default.
+    private val initialRegion: Rect? = initial?.region
+    private var firstRegion: Rect = initialRegion ?: defaultRegion
 
-    private var _region by mutableStateOf(defaultRegion)
+    private var _region by mutableStateOf(firstRegion)
     override var region
         get() = _region
         set(value) {
@@ -90,9 +94,13 @@ fun cropState(
             shape = it
         }
 
-        firstRegion = style.aspects.firstOrNull()?.let {
-            this.region.setAspect(it)
-        } ?: defaultRegion
+        // A seeded initial region wins over the style's default aspect, so
+        // re-crop opens exactly where the user left off.
+        firstRegion = initialRegion
+            ?: style.aspects.firstOrNull()?.let {
+                this.region.setAspect(it)
+            }
+            ?: defaultRegion
         _region = firstRegion
 
         defaultAspectLock = (style.aspects.size == 1).also {

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/ImageCropper.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/ImageCropper.kt
@@ -1,6 +1,7 @@
 package com.attafitamim.krop.core.crop
 
 import androidx.compose.runtime.*
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.unit.IntSize
 import com.attafitamim.krop.core.images.ImageBitmapSrc
@@ -22,6 +23,32 @@ enum class CropError : CropResult {
     LoadingError,
     /** The result could not be saved. Try reducing the maxSize supplied to [imageCropper.crop] */
     SavingError
+}
+
+/**
+ * The geometry of an accepted crop — enough to re-apply the crop to the
+ * original image later, without storing a rendered bitmap. This is the building
+ * block for **non-destructive cropping**: keep the original image and persist a
+ * [CropRegion], then re-render (or re-open the cropper seeded with it) on demand.
+ */
+data class CropRegion(
+    /** Crop rectangle, in the source image's pixel coordinates. */
+    val region: Rect,
+    /** Rotation / flip applied to the image ([ImgTransform.Identity] when none). */
+    val transform: ImgTransform,
+    /** Source image dimensions, so [region] can be normalised for storage. */
+    val imageSize: IntSize,
+)
+
+/** Union type denoting the possible results of an [ImageCropper.cropRegion] session. */
+sealed interface CropRegionResult {
+    data class Success(val cropRegion: CropRegion) : CropRegionResult
+
+    /** The user has cancelled the operation or another session was started. */
+    data object Cancelled : CropRegionResult
+
+    /** The supplied image is invalid, unsupported, or could not be read. */
+    data object LoadingError : CropRegionResult
 }
 
 enum class CropperLoading {
@@ -55,6 +82,19 @@ interface ImageCropper {
         maxResultSize: IntSize? = DefaultMaxCropSize,
         createSrc: suspend () -> ImageSrc?
     ): CropResult
+
+    /**
+     * Initiates a new crop session like [crop], but returns the crop **geometry**
+     * ([CropRegion]) instead of a rendered bitmap. No result image is produced.
+     *
+     * Use this for non-destructive cropping: keep the original image and persist
+     * the returned [CropRegion] to re-apply the crop on demand. Suspends until the
+     * session ends (accept / cancel / load error). [createSrc] builds the
+     * [ImageSrc] to crop.
+     */
+    suspend fun cropRegion(
+        createSrc: suspend () -> ImageSrc?
+    ): CropRegionResult
 }
 
 /**
@@ -77,6 +117,22 @@ suspend fun ImageCropper.crop(
     imageSrc
 }
 
+/**
+ * [cropRegion] overload sourcing the session from an in-memory [bmp]. Returns the
+ * crop geometry for non-destructive use.
+ */
+suspend fun ImageCropper.cropRegion(
+    bmp: ImageBitmap
+): CropRegionResult = cropRegion {
+    ImageBitmapSrc(bmp)
+}
+
+suspend fun ImageCropper.cropRegion(
+    imageSrc: ImageSrc?
+): CropRegionResult = cropRegion {
+    imageSrc
+}
+
 @Composable
 fun rememberImageCropper() : ImageCropper {
     return remember { imageCropper() }
@@ -89,22 +145,46 @@ fun imageCropper(): ImageCropper = object : ImageCropper {
     override var cropState: CropState? by mutableStateOf(null)
     private val cropStateFlow = snapshotFlow { cropState }
     override var loadingStatus: CropperLoading? by mutableStateOf(null)
+
     override suspend fun crop(
         maxResultSize: IntSize?,
         createSrc: suspend () -> ImageSrc?
     ): CropResult {
-        cropState = null
-        val src = withLoading(CropperLoading.PreparingImage) { createSrc() }
-            ?: return CropError.LoadingError
-        val newCrop = cropState(src) { cropState = null }
-        cropState = newCrop
-        cropStateFlow.takeWhile { it === newCrop }.collect()
+        val newCrop = runSession(createSrc) ?: return CropError.LoadingError
         if (!newCrop.accepted) return CropResult.Cancelled
         return withLoading(CropperLoading.SavingResult) {
             val result = newCrop.createResult(maxResultSize)
             if (result == null) CropError.SavingError
             else CropResult.Success(result)
         }
+    }
+
+    override suspend fun cropRegion(
+        createSrc: suspend () -> ImageSrc?
+    ): CropRegionResult {
+        val newCrop = runSession(createSrc) ?: return CropRegionResult.LoadingError
+        if (!newCrop.accepted) return CropRegionResult.Cancelled
+        return CropRegionResult.Success(
+            CropRegion(
+                region = newCrop.region,
+                transform = newCrop.transform,
+                imageSize = newCrop.src.size,
+            )
+        )
+    }
+
+    /**
+     * Prepares the image, starts a crop session, and suspends until it ends.
+     * Returns the (possibly un-accepted) [CropState], or null if the image
+     * failed to load. Shared by [crop] and [cropRegion].
+     */
+    private suspend fun runSession(createSrc: suspend () -> ImageSrc?): CropState? {
+        cropState = null
+        val src = withLoading(CropperLoading.PreparingImage) { createSrc() } ?: return null
+        val newCrop = cropState(src) { cropState = null }
+        cropState = newCrop
+        cropStateFlow.takeWhile { it === newCrop }.collect()
+        return newCrop
     }
 
     inline fun <R> withLoading(status: CropperLoading, op: () -> R): R {

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/ImageCropper.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/ImageCropper.kt
@@ -91,8 +91,12 @@ interface ImageCropper {
      * the returned [CropRegion] to re-apply the crop on demand. Suspends until the
      * session ends (accept / cancel / load error). [createSrc] builds the
      * [ImageSrc] to crop.
+     *
+     * Pass [initial] to seed the session at a previously-saved [CropRegion], so a
+     * "re-crop" opens exactly where the user left off instead of the full image.
      */
     suspend fun cropRegion(
+        initial: CropRegion? = null,
         createSrc: suspend () -> ImageSrc?
     ): CropRegionResult
 }
@@ -119,17 +123,19 @@ suspend fun ImageCropper.crop(
 
 /**
  * [cropRegion] overload sourcing the session from an in-memory [bmp]. Returns the
- * crop geometry for non-destructive use.
+ * crop geometry for non-destructive use. Pass [initial] to seed a re-crop.
  */
 suspend fun ImageCropper.cropRegion(
-    bmp: ImageBitmap
-): CropRegionResult = cropRegion {
+    bmp: ImageBitmap,
+    initial: CropRegion? = null
+): CropRegionResult = cropRegion(initial) {
     ImageBitmapSrc(bmp)
 }
 
 suspend fun ImageCropper.cropRegion(
-    imageSrc: ImageSrc?
-): CropRegionResult = cropRegion {
+    imageSrc: ImageSrc?,
+    initial: CropRegion? = null
+): CropRegionResult = cropRegion(initial) {
     imageSrc
 }
 
@@ -150,7 +156,8 @@ fun imageCropper(): ImageCropper = object : ImageCropper {
         maxResultSize: IntSize?,
         createSrc: suspend () -> ImageSrc?
     ): CropResult {
-        val newCrop = runSession(createSrc) ?: return CropError.LoadingError
+        val newCrop = runSession(initial = null, createSrc = createSrc)
+            ?: return CropError.LoadingError
         if (!newCrop.accepted) return CropResult.Cancelled
         return withLoading(CropperLoading.SavingResult) {
             val result = newCrop.createResult(maxResultSize)
@@ -160,9 +167,11 @@ fun imageCropper(): ImageCropper = object : ImageCropper {
     }
 
     override suspend fun cropRegion(
+        initial: CropRegion?,
         createSrc: suspend () -> ImageSrc?
     ): CropRegionResult {
-        val newCrop = runSession(createSrc) ?: return CropRegionResult.LoadingError
+        val newCrop = runSession(initial = initial, createSrc = createSrc)
+            ?: return CropRegionResult.LoadingError
         if (!newCrop.accepted) return CropRegionResult.Cancelled
         return CropRegionResult.Success(
             CropRegion(
@@ -174,14 +183,17 @@ fun imageCropper(): ImageCropper = object : ImageCropper {
     }
 
     /**
-     * Prepares the image, starts a crop session, and suspends until it ends.
-     * Returns the (possibly un-accepted) [CropState], or null if the image
-     * failed to load. Shared by [crop] and [cropRegion].
+     * Prepares the image, starts a crop session (optionally seeded at [initial]),
+     * and suspends until it ends. Returns the (possibly un-accepted) [CropState],
+     * or null if the image failed to load. Shared by [crop] and [cropRegion].
      */
-    private suspend fun runSession(createSrc: suspend () -> ImageSrc?): CropState? {
+    private suspend fun runSession(
+        initial: CropRegion?,
+        createSrc: suspend () -> ImageSrc?
+    ): CropState? {
         cropState = null
         val src = withLoading(CropperLoading.PreparingImage) { createSrc() } ?: return null
-        val newCrop = cropState(src) { cropState = null }
+        val newCrop = cropState(src, initial) { cropState = null }
         cropState = newCrop
         cropStateFlow.takeWhile { it === newCrop }.collect()
         return newCrop

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toSize
+import com.attafitamim.krop.core.images.ImageBitmapSrc
+import com.attafitamim.krop.core.images.ImageSrc
 import com.attafitamim.krop.core.images.getDecodeParams
 import com.attafitamim.krop.core.utils.atOrigin
 import com.attafitamim.krop.core.utils.coerceAtMost
@@ -28,6 +30,34 @@ suspend fun CropState.createResult(
         .onFailure { it.printStackTrace() }
         .getOrNull()
 }
+
+/**
+ * Renders the crop described by [cropRegion] onto [src] **off-screen** — the
+ * non-interactive counterpart of [ImageCropper.cropRegion]. Produces the cropped
+ * image on demand from a persisted [CropRegion] (non-destructive cropping) via
+ * the same pipeline the interactive cropper uses, so the result matches what the
+ * user saw. [maxSize] scales the result down if provided. Returns null if the
+ * image could not be decoded.
+ */
+suspend fun renderCropRegion(
+    src: ImageSrc,
+    cropRegion: CropRegion,
+    maxSize: IntSize? = DefaultMaxCropSize,
+): ImageBitmap? {
+    val state = cropState(src)
+    // Order matters: the region setter constrains against the transformed image
+    // bounds, so apply the transform first.
+    state.transform = cropRegion.transform
+    state.region = cropRegion.region
+    return state.createResult(maxSize)
+}
+
+/** [renderCropRegion] overload sourcing from an in-memory [bmp]. */
+suspend fun renderCropRegion(
+    bmp: ImageBitmap,
+    cropRegion: CropRegion,
+    maxSize: IntSize? = DefaultMaxCropSize,
+): ImageBitmap? = renderCropRegion(ImageBitmapSrc(bmp), cropRegion, maxSize)
 
 suspend fun CropState.doCreateResult(maxSize: IntSize?): ImageBitmap? {
     val finalSize = region.size

--- a/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
+++ b/library/core/src/commonMain/kotlin/com/attafitamim/krop/core/crop/Result.kt
@@ -52,7 +52,9 @@ suspend fun renderCropRegion(
     return state.createResult(maxSize)
 }
 
-/** [renderCropRegion] overload sourcing from an in-memory [bmp]. */
+/**
+ * [renderCropRegion] overload sourcing from an in-memory [bmp].
+ */
 suspend fun renderCropRegion(
     bmp: ImageBitmap,
     cropRegion: CropRegion,


### PR DESCRIPTION
Adds a non-destructive crop round-trip. You can pull the crop geometry out of the interactive cropper, apply a saved geometry back off-screen, and reopen the cropper seeded at a saved crop. All of it reuses the existing `cropState` and `createResult` pipeline, so `crop()` stays unchanged (the shared session logic moved into a private `runSession()`).

## Added APIs
- `ImageCropper.cropRegion(initial, createSrc)` runs the interactive crop session and returns the crop geometry instead of a rendered bitmap. Has `ImageBitmap` and `ImageSrc` overloads.
- `CropRegion(region: Rect, transform: ImgTransform, imageSize: IntSize)` is the crop spec.
- `CropRegionResult` is `Success(cropRegion)`, `Cancelled` or `LoadingError`.
- `renderCropRegion(src | bitmap, cropRegion, maxSize)` returns an `ImageBitmap` by applying a saved `CropRegion` off-screen. The result matches what the cropper preview showed.
- The optional `initial` parameter on `cropRegion()` (and the `cropState()` factory) seeds the session at a saved `CropRegion`, so a re-crop opens where the user left off instead of at the full image.

## Use cases
- Keep the original image, persist only the crop, and re-render on demand at any size.
- Re-crop losslessly any number of times, starting from the previous crop.
- Export or sync the original plus the framing. A small rect travels, whereas a pre-rendered crop locks the framing forever.

## Notes
- `crop()` behaviour is unchanged and there is no UI or dialog change. A seeded region wins over the style default aspect inside `setInitialState()`.
- Compiled against the desktop target. Happy to add tests and a sample once the shape looks right.
- Open question. Should `region` stay in source pixels (as here, with `imageSize` alongside) or be returned normalized to 0..1.
